### PR TITLE
Loot table warning

### DIFF
--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -57,6 +57,9 @@ export function ChestsPage() {
 					onChange={(e) => setSearchQuery(e.target.value)}
 					className="w-full sm:max-w-xs"
 				/>
+				<p className="text-sm sm:text-base text-white/50">
+					Search for multiple items or chests by separating them with space.
+				</p>
 			</div>
 
 			{/* Loading state */}

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -58,7 +58,8 @@ export function ChestsPage() {
 					className="w-full sm:max-w-xs"
 				/>
 				<p className="text-sm sm:text-base text-white/50">
-					Search for multiple items or chests by separating terms with spaces; results match if any term is found.
+					Search for multiple items or chests by separating terms with spaces;
+					results match if any term is found.
 				</p>
 			</div>
 

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -62,6 +62,18 @@ export function ChestsPage() {
 				</p>
 			</div>
 
+			{/* Warning about missing catalyst fragments and calculations */}
+			<div className="flex flex-col gap-4 mb-4 p-4 bg-yellow-900/30 border-l-4 border-yellow-500">
+				<p className="text-sm sm:text-base text-yellow-300">
+					⚠️ Wooden tables are missing catalyst fragment dat. This will be
+					resolved in a future update.
+				</p>
+				<p className="text-sm sm:text-base text-yellow-300">
+					⚠️ Calculations have not been double-checked for accuracy and may be
+					slightly off.
+				</p>
+			</div>
+
 			{/* Loading state */}
 			{loading && <LoadingState />}
 

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -65,8 +65,8 @@ export function ChestsPage() {
 			{/* Warning about missing catalyst fragments and calculations */}
 			<div className="flex flex-col gap-4 mb-4 p-4 bg-yellow-900/30 border-l-4 border-yellow-500">
 				<p className="text-sm sm:text-base text-yellow-300">
-					⚠️ Wooden tables are missing catalyst fragment dat. This will be
-					resolved in a future update.
+					⚠️ Wooden chest loot tables are missing catalyst fragment data. This
+					will be resolved in a future update.
 				</p>
 				<p className="text-sm sm:text-base text-yellow-300">
 					⚠️ Calculations have not been double-checked for accuracy and may be

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -58,7 +58,7 @@ export function ChestsPage() {
 					className="w-full sm:max-w-xs"
 				/>
 				<p className="text-sm sm:text-base text-white/50">
-					Search for multiple items or chests by separating them with space.
+					Search for multiple items or chests by separating terms with spaces; results match if any term is found.
 				</p>
 			</div>
 


### PR DESCRIPTION
## Description

Add warning information about incorrect calculations for Loot Table Chests. Also add more information about how the search works.

Closes #30 

## Changes

<img width="1207" height="460" alt="image" src="https://github.com/user-attachments/assets/2066700f-b322-4e9a-a568-da8db32954d6" />

## Checklist

- [ ] I have reviewed my own code
- [x] Tested locally with `yarn dev`
