### PR TITLE
Catalyst fragments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,5 +23,6 @@
 
 ## Repo-specific conventions
 - Formatting is enforced by Biome; indentation is **tabs** in TS/TSX (see `biome.json`). Prefer double quotes and trailing commas.
+- Avoid ALL_CAPS constants; use camelCase instead.
 - Tailwind CSS is integrated via `@tailwindcss/vite` and `@import "tailwindcss";` in `src/index.css` (no Tailwind config file).
 - Settings persistence uses versioned localStorage keys; for chests: `vh.community.lootTables.chests.settings.v1` in `src/loot-tables/chests/settingsStorage.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-02-17 Catalyst Fragments And Fixed Item Quantity
+
+### Added
+
+- Catalyst Fragments were not showing up in the wooden loot table since they not part of the loot table for the wooden chest.
+  Instead they are added as a bonus item after the loot table rolls.
+
+## Fixes
+
+- Item Quantity did not work properly except at 0%, 100%, 200%, and 300%. This is now fixed and it works properly at all values.
+
 ## 2026-02-14 Icons & URLs
 
 ### Improvements

--- a/docs/CatalystFragments.md
+++ b/docs/CatalystFragments.md
@@ -1,0 +1,80 @@
+# Catalyst Fragment Generation in Wooden Chests
+
+## Overview
+
+Catalyst fragments (`the_vault:vault_catalyst_fragment`) can be found in wooden chests inside Vault Hunters. Unlike regular loot items, they are **not part of any loot table pool**. Instead, they are generated as a separate post-loot step in `ClassicLootLogic.generateCatalystFragments()`.
+
+## Prerequisites
+
+For catalyst fragments to have a chance of appearing in a wooden chest, **all** of the following must be true:
+
+1. **Vault level ≥ 20** (configured as `catalystMinLevel` in `vault_chest_meta.json`)
+2. **Crystal must allow catalyst generation** — the crystal's `canGenerateCatalystFragments()` must return `true`, which requires either:
+   - The crystal has random modifiers (`hasRandomModifiers()` — i.e., an **unmodified vault**), OR
+   - The crystal has an `AscensionCrystalObjective`
+3. **Not an Architect vault** — if the vault has an `ArchitectObjective` and no `ChanceCatalystModifier`, catalyst fragment generation is disabled
+
+## Probability by Chest Rarity
+
+The chance of receiving a catalyst fragment depends on the **VaultRarity** assigned to the chest after its loot is generated:
+
+| Chest Rarity | Catalyst Fragment Probability |
+|--------------|-------------------------------|
+| COMMON       | 5%                            |
+| RARE         | 20%                           |
+| EPIC         | 50%                           |
+| OMEGA        | 100%                          |
+
+Source: `the_vault/vault_chest_meta.json` → `catalystChances` → `the_vault:wooden_chest`
+
+## Stack Size
+
+When the probability check passes, exactly **1 catalyst fragment** is added. The stack size is always 1 — there is no count range or uniform distribution like regular loot table items.
+
+## Roll Tiers
+
+Catalyst fragments are **not rolled within any tier** of the wooden chest loot table. The wooden chest loot table has 4 tiers (weight 70, 20, 8, 2), but catalyst fragments bypass this system entirely. They are a simple probability check that runs after the loot table generation is complete.
+
+## Effect of Item Quantity
+
+**Item Quantity does NOT affect catalyst fragments.**
+
+The fragment is added via `data.getLoot().add(new ItemStack(ModItems.VAULT_CATALYST_FRAGMENT))` — a fixed stack of 1. It completely bypasses the `TieredLootTableGenerator` and its item quantity multiplier logic.
+
+## Effect of Item Rarity
+
+Item Rarity has an **indirect effect**:
+
+1. Item Rarity boosts the weights of non-common tiers in the `TieredLootTableGenerator` (tiers at index 1, 2, 3 get their weights multiplied by `1 + itemRarity`)
+2. This changes the distribution of rolls across tiers, affecting the CDF (cumulative distribution function) score
+3. The CDF score determines the chest's `VaultRarity` (COMMON / RARE / EPIC / OMEGA)
+4. Higher VaultRarity → higher catalyst fragment probability
+
+So: **more Item Rarity → better chance of a higher-rarity chest → better chance of catalyst fragments**.
+
+## Timing: Before or After Initial Rolls?
+
+Catalyst fragments are added **AFTER** the initial loot rolls. The generation flow is:
+
+1. `VaultChestTileEntity.generateLootTable()` — runs `TieredLootTableGenerator`, rolls all normal loot, determines VaultRarity from CDF
+2. `ChestGenerationEvent` POST phase fires
+3. `ClassicLootLogic.onChestPostGenerate()` is called:
+   - `generateCatalystFragments()` — appends catalyst fragment to `data.getLoot()` if check passes
+   - `generateRelicFragments()` — runs separately
+   - `initializeLoot()` — finalizes loot
+4. `VaultChestTileEntity.fillLoot()` — places all items (including catalyst fragment) into chest slots
+
+**Conclusion: Catalyst fragments do NOT decrease the number of other items in the chest. They are bonus items added on top of the normal loot.**
+
+## Modifier: ChanceCatalystModifier
+
+The `ChanceCatalystModifier` vault modifier can **additively increase** the catalyst fragment probability. It registers on the `CHEST_CATALYST_GENERATION` event and adds its configured chance value to the base probability before the final roll. This modifier can also enable catalyst fragment generation even when `ADD_CATALYST_FRAGMENTS` is not set (e.g., in modified vaults).
+
+## Source Files
+
+- `iskallia/vault/core/vault/ClassicLootLogic.java` — `generateCatalystFragments()` method
+- `iskallia/vault/config/VaultMetaChestConfig.java` — `getCatalystChance()`, `getCatalystMinLevel()`
+- `the_vault/vault_chest_meta.json` — configured probabilities and min level
+- `iskallia/vault/block/entity/VaultChestTileEntity.java` — chest generation flow
+- `iskallia/vault/item/crystal/CrystalData.java` — `canGenerateCatalystFragments()`
+- `iskallia/vault/core/vault/modifier/modifier/ChanceCatalystModifier.java` — modifier logic

--- a/docs/ChestRarity.md
+++ b/docs/ChestRarity.md
@@ -1,0 +1,113 @@
+# Chest Rarity System (VaultRarity) in Vault Hunters
+
+## Overview
+
+Every non-treasure vault chest is assigned a **VaultRarity** when opened: COMMON, RARE, EPIC, or OMEGA. This rarity is **not pre-determined** — it is calculated from the actual loot roll distribution using a CDF (Cumulative Distribution Function) score.
+
+## How Rarity is Determined
+
+1. The `TieredLootTableGenerator` rolls items across 4 tier pools (e.g., for wooden chest: weights 70, 20, 8, 2)
+2. Each roll randomly picks one of the 4 tiers based on their weights
+3. After all rolls, a CDF score is computed — this represents the probability of getting a roll distribution at least as rare as the one that occurred
+4. `VaultChestConfig.getRarity(cdf)` maps the CDF score to a VaultRarity using configured thresholds
+
+A **lower CDF** means a luckier (rarer) outcome.
+
+## Rarity Thresholds
+
+From `the_vault/vault_chest.json`:
+
+| Rarity | CDF Condition | Approx. Probability (base stats) |
+|--------|---------------|----------------------------------|
+| OMEGA  | CDF < 0.03    | ~3%                              |
+| EPIC   | CDF < 0.10    | ~7%                              |
+| RARE   | CDF < 0.30    | ~20%                             |
+| COMMON | CDF ≥ 0.30    | ~70%                             |
+
+**Note:** Due to the discrete nature of the CDF (finite number of possible roll distributions), actual probabilities may differ slightly from these thresholds. With 12–15 rolls across 4 pools (wooden chest), the distribution is smooth enough that these approximations are close.
+
+## What's Different in Each Rarity?
+
+### Loot Quality (Primary Effect)
+
+The rarity is a **label that reflects the roll outcome**, not a modifier applied after the fact. A higher-rarity chest already contains better items because more rolls landed in the higher-tier pools during generation.
+
+For example, in a wooden chest:
+- **Tier 0** (weight 70) — common items: wooden chunks, sandy rocks, vault sweets, etc.
+- **Tier 1** (weight 20) — rare items: magic silk, carbon nuggets, driftwood, vault plating
+- **Tier 2** (weight 8) — epic items: shulker shells, vault essence, silver scraps
+- **Tier 3** (weight 2) — omega items: chest scrolls, mod boxes, bounty pearls
+
+An OMEGA chest means an unusually high proportion of rolls went to Tiers 1–3 instead of Tier 0.
+
+### Post-Generation Bonuses
+
+Higher rarity provides better chances for additional bonus items added after the main loot:
+
+**Catalyst Fragment Chance** (wooden chest, unmodified vault, level ≥ 20):
+
+| Rarity | Catalyst Fragment Probability |
+|--------|-------------------------------|
+| COMMON | 5%                            |
+| RARE   | 20%                           |
+| EPIC   | 50%                           |
+| OMEGA  | 100%                          |
+
+**Companion Relic Fragment Chance:** Scales with rarity (configured separately in `companion_relics.json`).
+
+**Companion Particle Trail Chance:** Scales with rarity (configured separately in `companion_relics.json`).
+
+### Visual & Audio Effects
+
+| Rarity | Sound Effect             | Particles              |
+|--------|--------------------------|------------------------|
+| COMMON | Standard chest open      | None                   |
+| RARE   | `vault_chest_rare_open`  | None                   |
+| EPIC   | `vault_chest_epic_open`  | Purple/magenta dust    |
+| OMEGA  | `vault_chest_omega_open` | Green dust             |
+
+### Display Name
+
+The chest's display name includes the rarity as a prefix:
+- "Wooden Chest" → "Rare Wooden Chest", "Epic Wooden Chest", "Omega Wooden Chest"
+- Same pattern for Gilded, Living, Ornate, Altar, Hardened, Enigma, Flesh chests
+- Treasure chests always display as "Treasure Chest" (they use a different generator and are always COMMON rarity)
+
+## Does Item Rarity Affect Chest Rarity?
+
+**Yes.** Item Rarity directly increases the probability of getting a higher-rarity chest.
+
+In `TieredLootTableGenerator.generateEntry()`, the weights of **non-common tier pools** (index 1, 2, 3) are multiplied by `(1 + itemRarity)`:
+
+```
+adjustedPool weight[0] = base weight (unchanged)
+adjustedPool weight[1] = base weight × (1 + itemRarity)
+adjustedPool weight[2] = base weight × (1 + itemRarity)
+adjustedPool weight[3] = base weight × (1 + itemRarity)
+```
+
+For a wooden chest with base weights [70, 20, 8, 2] and 50% Item Rarity:
+- Adjusted weights: [70, 30, 12, 3] (total 115)
+- Tier 0 probability drops from 70% to ~60.9%
+- Higher tiers become more likely → lower CDF → higher VaultRarity chance
+
+**Important:** The CDF is computed against the **base** (unadjusted) weights, but the actual rolls use the **adjusted** weights. This means Item Rarity makes you roll more rare-tier items, and the CDF calculation (which uses base weights) sees this as a very lucky outcome, resulting in a lower CDF and higher rarity classification.
+
+## Does Item Quantity Affect Chest Rarity?
+
+**Not directly.** Item Quantity affects the **number of rolls** (more rolls = more items), but does not change the tier weight distribution. The CDF is computed for the specific number of rolls that occurred, so having more rolls doesn't inherently bias toward a higher or lower CDF.
+
+However, more rolls does slightly affect the CDF distribution shape — with more rolls, extreme outcomes become less likely (law of large numbers), so the CDF values tend to cluster more toward the center. This is a minor statistical effect, not a direct mechanical one.
+
+## Exception: Treasure Chests
+
+Treasure chests use a plain `LootTableGenerator` (not `TieredLootTableGenerator`) and are always assigned `VaultRarity.COMMON`. They do not participate in the CDF-based rarity system.
+
+## Source Files
+
+- `iskallia/vault/config/VaultChestConfig.java` — `getRarity()`, `RARITY_DISTRIBUTION`
+- `the_vault/vault_chest.json` — configured rarity thresholds (0.03, 0.10, 0.30)
+- `iskallia/vault/core/world/loot/generator/TieredLootTableGenerator.java` — CDF computation, Item Rarity weight boost
+- `iskallia/vault/block/entity/VaultChestTileEntity.java` — rarity assignment, sounds, particles, display names
+- `iskallia/vault/core/vault/ClassicLootLogic.java` — post-generation rarity-dependent bonuses
+- `iskallia/vault/util/VaultRarity.java` — enum: COMMON, RARE, EPIC, OMEGA

--- a/docs/ItemQuantity.md
+++ b/docs/ItemQuantity.md
@@ -6,10 +6,12 @@ It increases both the amount of rolls and the stack size of each roll, so it has
 
 ## Formula
 
-```javascript
-minRoll = min(54, floor(minRoll * (1 + itemQuantity)))
-maxRoll = min(54, floor(maxRoll * (1 + itemQuantity)))
+The game uses stochastic rounding: each whole unit is guaranteed, and the fractional remainder is a probability of +1. The expected value therefore equals the continuous product — no flooring.
 
-minStack = floor(minStack * (1 + itemQuantity))
-maxStack = floor(maxStack * (1 + itemQuantity))
+```javascript
+minRoll = min(54, minRoll * (1 + itemQuantity))
+maxRoll = min(54, maxRoll * (1 + itemQuantity))
+
+minStack = minStack * (1 + itemQuantity)
+maxStack = maxStack * (1 + itemQuantity)
 ```

--- a/public/data/loot_tables/chest_wooden_catalyst.json
+++ b/public/data/loot_tables/chest_wooden_catalyst.json
@@ -1,6 +1,6 @@
 {
   "id": "chest_wooden_catalyst",
-  "tier": "unmodified",
+  "group": "unmodified",
   "levelRequirement": 20,
   "items": [
     {

--- a/public/data/loot_tables/chest_wooden_catalyst.json
+++ b/public/data/loot_tables/chest_wooden_catalyst.json
@@ -1,5 +1,6 @@
 {
   "id": "chest_wooden_catalyst",
+  "tier": "unmodified",
   "levelRequirement": 20,
   "items": [
     {

--- a/public/data/loot_tables/chest_wooden_catalyst.json
+++ b/public/data/loot_tables/chest_wooden_catalyst.json
@@ -1,0 +1,16 @@
+{
+  "id": "chest_wooden_catalyst",
+  "levelRequirement": 20,
+  "items": [
+    {
+      "id": "the_vault:vault_catalyst_fragment",
+      "count": 1,
+      "rollChanges": {
+        "common": 0.05,
+        "rare": 0.2,
+        "epic": 0.5,
+        "omega": 1
+      }
+    }
+  ]
+}

--- a/public/data/loot_tables/index.json
+++ b/public/data/loot_tables/index.json
@@ -33,5 +33,11 @@
     "id": "enigma_chest",
     "type": "chest",
     "file": "chest_enigma.json"
+  },
+  {
+    "id": "chest_wooden_catalyst",
+    "parentId": "chest_wooden",
+    "type": "chest_addon",
+    "file": "chest_wooden_catalyst.json"
   }
 ]

--- a/public/data/loot_tables/index.json
+++ b/public/data/loot_tables/index.json
@@ -36,7 +36,7 @@
   },
   {
     "id": "chest_wooden_catalyst",
-    "parentId": "chest_wooden",
+    "parentId": "wooden_chest",
     "type": "chest_addon",
     "file": "chest_wooden_catalyst.json"
   }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+interface TooltipProps {
+	text: string
+	children: React.ReactNode
+}
+
+/**
+ * Tooltip that shows on hover (desktop) and tap toggle (mobile).
+ * Styled to match the app's window aesthetic: no rounded corners,
+ * semi-transparent black background with gold ring.
+ */
+export function Tooltip({ text, children }: TooltipProps) {
+	const [visible, setVisible] = useState(false)
+	const containerRef = useRef<HTMLButtonElement>(null)
+
+	// Close on outside click (mobile dismiss)
+	useEffect(() => {
+		if (!visible) return
+
+		function handleClickOutside(e: MouseEvent) {
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(e.target as Node)
+			) {
+				setVisible(false)
+			}
+		}
+
+		document.addEventListener("click", handleClickOutside)
+		return () => document.removeEventListener("click", handleClickOutside)
+	}, [visible])
+
+	const handleClick = useCallback((e: React.MouseEvent) => {
+		e.stopPropagation()
+		setVisible((v) => !v)
+	}, [])
+
+	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault()
+			setVisible((v) => !v)
+		}
+		if (e.key === "Escape") {
+			setVisible(false)
+		}
+	}, [])
+
+	return (
+		<button
+			ref={containerRef}
+			type="button"
+			className="relative cursor-help bg-transparent border-none p-0 font-inherit text-inherit text-left"
+			onMouseEnter={() => setVisible(true)}
+			onMouseLeave={() => setVisible(false)}
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+		>
+			{children}
+			{visible && (
+				<span
+					role="tooltip"
+					className="absolute bottom-full left-0 mb-1 z-50 whitespace-nowrap px-3 py-1.5 text-sm text-white bg-black/60 backdrop-blur-md shadow-lg ring-1 ring-gold/10"
+				>
+					{text}
+				</span>
+			)}
+		</button>
+	)
+}

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -1,0 +1,1 @@
+export type ItemId = string & { __brand__: "ItemId" }

--- a/src/models/jsonIndex.ts
+++ b/src/models/jsonIndex.ts
@@ -2,12 +2,16 @@
 // Elements are sorted and should be displayed in the order they are added to the index.
 export type JsonIndex = JsonIndexEntry[]
 
+export type IndexId = string & { __brand__: "IndexId" }
+
 export interface JsonIndexEntry {
-	id: string
+	id: IndexId
+	parentId?: IndexId
 	type: JsonIndexTypes
 	file: string
 }
 
 export enum JsonIndexTypes {
 	chest = "chest",
+	chestAddon = "chest_addon",
 }

--- a/src/models/tieredLootTable.ts
+++ b/src/models/tieredLootTable.ts
@@ -1,3 +1,5 @@
+import type { ItemId } from "@models/item"
+
 export interface TieredLootTable {
 	name: string
 	levels: TieredLootTableLevel[]
@@ -23,7 +25,7 @@ export interface LevelPool {
 }
 
 export interface ItemPool {
-	id: string
+	id: ItemId
 	weight: number
 	count: Range
 }

--- a/src/models/tieredLootTableAddon.ts
+++ b/src/models/tieredLootTableAddon.ts
@@ -1,0 +1,24 @@
+// Tiered Loot Table Addon is for adding loot after the main loot table rolls.
+// This allows to add additional items to the loot without affecting the main loot table probabilities.
+// Examples of this includes the catalyst fragments from wooden chests,
+
+import type { ItemId } from "./item"
+import type { IndexId } from "./jsonIndex"
+
+// or scavenger items from the scavenger vaults.
+export interface TieredLootTableAddon {
+	id: IndexId
+	levelRequirement: number
+	items: TieredLootTableAddonItem[]
+}
+
+export interface TieredLootTableAddonItem {
+	id: ItemId
+	count: number
+	rollChanges: {
+		common: number
+		rare: number
+		epic: number
+		omega: number
+	}
+}

--- a/src/models/tieredLootTableAddon.ts
+++ b/src/models/tieredLootTableAddon.ts
@@ -1,11 +1,9 @@
 // Tiered Loot Table Addon is for adding loot after the main loot table rolls.
-// This allows to add additional items to the loot without affecting the main loot table probabilities.
-// Examples of this includes the catalyst fragments from wooden chests.
+// This allows adding additional items to the loot without affecting the main loot table probabilities.
+// Examples of this include the catalyst fragments from wooden chests or scavenger items from the scavenger vaults.
 
 import type { ItemId } from "./item"
 import type { IndexId } from "./jsonIndex"
-
-// or scavenger items from the scavenger vaults.
 export interface TieredLootTableAddon {
 	id: IndexId
 	levelRequirement: number

--- a/src/models/tieredLootTableAddon.ts
+++ b/src/models/tieredLootTableAddon.ts
@@ -9,6 +9,7 @@ import type { IndexId } from "./jsonIndex"
 export interface TieredLootTableAddon {
 	id: IndexId
 	levelRequirement: number
+	group: AddonGroups
 	items: TieredLootTableAddonItem[]
 }
 
@@ -21,4 +22,8 @@ export interface TieredLootTableAddonItem {
 		epic: number
 		omega: number
 	}
+}
+
+export enum AddonGroups {
+	unmodified = "unmodified",
 }

--- a/src/models/tieredLootTableAddon.ts
+++ b/src/models/tieredLootTableAddon.ts
@@ -1,6 +1,6 @@
 // Tiered Loot Table Addon is for adding loot after the main loot table rolls.
 // This allows to add additional items to the loot without affecting the main loot table probabilities.
-// Examples of this includes the catalyst fragments from wooden chests,
+// Examples of this includes the catalyst fragments from wooden chests.
 
 import type { ItemId } from "./item"
 import type { IndexId } from "./jsonIndex"

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -23,7 +23,6 @@ export function ChestsPage() {
 		indexEntries,
 		chestResults,
 		loading,
-		// TODO: Add chest addons
 		error: indexError,
 	} = useChestData()
 

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -63,12 +63,8 @@ export function ChestsPage() {
 				</p>
 			</div>
 
-			{/* Warning about missing catalyst fragments and calculations */}
+			{/* Warning about calculation accuracy */}
 			<div className="flex flex-col gap-4 mb-4 p-4 bg-yellow-900/30 border-l-4 border-yellow-500">
-				<p className="text-sm sm:text-base text-yellow-300">
-					⚠️ Wooden chest loot tables are missing catalyst fragment data. This
-					will be resolved in a future update.
-				</p>
 				<p className="text-sm sm:text-base text-yellow-300">
 					⚠️ Calculations have not been double-checked for accuracy and may be
 					slightly off.

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -23,6 +23,7 @@ export function ChestsPage() {
 		indexEntries,
 		chestResults,
 		loading,
+		// TODO: Add chest addons
 		error: indexError,
 	} = useChestData()
 

--- a/src/pages/loot-tables/chests/ChestsPage.tsx
+++ b/src/pages/loot-tables/chests/ChestsPage.tsx
@@ -63,14 +63,6 @@ export function ChestsPage() {
 				</p>
 			</div>
 
-			{/* Warning about calculation accuracy */}
-			<div className="flex flex-col gap-4 mb-4 p-4 bg-yellow-900/30 border-l-4 border-yellow-500">
-				<p className="text-sm sm:text-base text-yellow-300">
-					⚠️ Calculations have not been double-checked for accuracy and may be
-					slightly off.
-				</p>
-			</div>
-
 			{/* Loading state */}
 			{loading && <LoadingState />}
 

--- a/src/pages/loot-tables/chests/ChestsTable.tsx
+++ b/src/pages/loot-tables/chests/ChestsTable.tsx
@@ -3,7 +3,7 @@ import { formatExpected } from "../shared/formatExpected"
 import type { GroupedItem } from "./aggregateByItemId"
 import type { ChestSection } from "./chestSection"
 import { getItem } from "./getItem"
-import { TIER_COLOR_CLASSES, TIER_LABELS } from "./tierStyles"
+import { getTierColorClass } from "./tierStyles"
 
 interface ChestsTableProps {
 	sections: ChestSection[]
@@ -111,7 +111,7 @@ function ItemRows({ item, chestId }: { item: GroupedItem; chestId: string }) {
 
 				return (
 					<tr
-						key={`${itemKey}-${tierBreakdown.tier}`}
+						key={`${itemKey}-${tierBreakdown.rollTierLabel}`}
 						data-item-group={itemKey}
 						className={`border-b border-white/5 ${isHovered ? "bg-white/5" : ""}`}
 						onMouseEnter={() => setIsHovered(true)}
@@ -148,9 +148,9 @@ function ItemRows({ item, chestId }: { item: GroupedItem; chestId: string }) {
 
 						{/* Tier column — background for this specific tier */}
 						<td
-							className={`px-1 sm:px-3 h-12 sm:h-14 ${TIER_COLOR_CLASSES[tierBreakdown.tier]}`}
+							className={`px-1 sm:px-3 h-12 sm:h-14 ${getTierColorClass(tierBreakdown.tier)}`}
 						>
-							{TIER_LABELS[tierBreakdown.tier]}
+							{tierBreakdown.rollTierLabel}
 						</td>
 
 						{/* Amount per X — also with tier background */}

--- a/src/pages/loot-tables/chests/ChestsTable.tsx
+++ b/src/pages/loot-tables/chests/ChestsTable.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react"
+import { Tooltip } from "../../../components/Tooltip"
 import { formatExpected } from "../shared/formatExpected"
-import type { GroupedItem } from "./aggregateByItemId"
+import type { GroupedItem, TierBreakdown } from "./aggregateByItemId"
 import type { ChestSection } from "./chestSection"
 import { getItem } from "./getItem"
-import { getTierColorClass } from "./tierStyles"
+import { addonGroupDescriptions, getTierColorClass } from "./tierStyles"
 
 interface ChestsTableProps {
 	sections: ChestSection[]
@@ -150,7 +151,7 @@ function ItemRows({ item, chestId }: { item: GroupedItem; chestId: string }) {
 						<td
 							className={`px-1 sm:px-3 h-12 sm:h-14 ${getTierColorClass(tierBreakdown.tier)}`}
 						>
-							{tierBreakdown.rollTierLabel}
+							<RollTierLabel breakdown={tierBreakdown} />
 						</td>
 
 						{/* Amount per X — also with tier background */}
@@ -164,6 +165,19 @@ function ItemRows({ item, chestId }: { item: GroupedItem; chestId: string }) {
 			})}
 		</>
 	)
+}
+
+function RollTierLabel({ breakdown }: { breakdown: TierBreakdown }) {
+	if (breakdown.addonGroup) {
+		const description =
+			addonGroupDescriptions[
+				breakdown.addonGroup as keyof typeof addonGroupDescriptions
+			]
+		if (description) {
+			return <Tooltip text={description}>{breakdown.rollTierLabel}</Tooltip>
+		}
+	}
+	return <>{breakdown.rollTierLabel}</>
 }
 
 function ExpectedAmount({ value }: { value: number }) {

--- a/src/pages/loot-tables/chests/aggregateByItemId.ts
+++ b/src/pages/loot-tables/chests/aggregateByItemId.ts
@@ -8,6 +8,8 @@ export interface TierBreakdown {
 	tier: TierName | null
 	/** Display label for the Roll Tier column (e.g., "Common" or "Unmodified") */
 	rollTierLabel: string
+	/** Addon group key, present only for addon rows (used for tooltip lookup) */
+	addonGroup?: string
 	expectedPerX: number
 }
 
@@ -50,7 +52,7 @@ export function aggregateByItemId(
 		string,
 		{
 			tiers: Map<TierName, number>
-			addonTiers: { label: string; expected: number }[]
+			addonTiers: { label: string; group: string; expected: number }[]
 			lowestTier: TierName | null
 		}
 	>()
@@ -83,7 +85,11 @@ export function aggregateByItemId(
 			map.set(addon.itemId, entry)
 		}
 		const label = addon.group.charAt(0).toUpperCase() + addon.group.slice(1)
-		entry.addonTiers.push({ label, expected: addon.expectedPerChest })
+		entry.addonTiers.push({
+			label,
+			group: addon.group,
+			expected: addon.expectedPerChest,
+		})
 	}
 
 	// Convert to sorted array
@@ -116,6 +122,7 @@ export function aggregateByItemId(
 				tiers.push({
 					tier: null,
 					rollTierLabel: addonTier.label,
+					addonGroup: addonTier.group,
 					expectedPerX: addonTier.expected * perXChests,
 				})
 			}

--- a/src/pages/loot-tables/chests/aggregateByItemId.ts
+++ b/src/pages/loot-tables/chests/aggregateByItemId.ts
@@ -1,10 +1,13 @@
 import type { TierName } from "../../../models/tieredLootTable"
 import { TIER_NAMES } from "../../../models/tieredLootTable"
+import type { AddonItemExpectation } from "./computeAddonExpectations"
 import type { ItemExpectation } from "./expectedValue"
 
 /** A tier-level breakdown for a grouped item row. */
 export interface TierBreakdown {
-	tier: TierName
+	tier: TierName | null
+	/** Display label for the Roll Tier column (e.g., "Common" or "Unmodified") */
+	rollTierLabel: string
 	expectedPerX: number
 }
 
@@ -13,9 +16,9 @@ export interface GroupedItem {
 	itemId: string
 	/** Total expected across all tiers for this item */
 	totalExpectedPerX: number
-	/** The lowest tier this item appears in (for item identity background color - FR-003a) */
-	lowestTier: TierName
-	/** Per-tier breakdown sub-rows (ordered Common → Rare → Epic → Omega) */
+	/** The lowest tier this item appears in (for item identity background color - FR-003a). Null for addon-only items. */
+	lowestTier: TierName | null
+	/** Per-tier breakdown sub-rows (ordered Common → Rare → Epic → Omega, then addons) */
 	tiers: TierBreakdown[]
 }
 
@@ -31,24 +34,31 @@ const TIER_ORDER: Record<TierName, number> = {
  * Aggregate item expectations by item id (FR-019, FR-020).
  * Items with the same id across tiers are grouped together.
  * Within each group, tier sub-rows are in canonical order.
+ * Addon items appear after regular tier sub-rows.
  * Groups are sorted by ascending item id (FR-020a).
  *
  * @param expectations Per-item expectations from computeItemExpectations
+ * @param addonExpectations Per-item expectations from computeAddonExpectations
  * @param perXChests Number of chests (X) to multiply by (FR-006)
  */
 export function aggregateByItemId(
 	expectations: ItemExpectation[],
+	addonExpectations: AddonItemExpectation[],
 	perXChests: number,
 ): GroupedItem[] {
 	const map = new Map<
 		string,
-		{ tiers: Map<TierName, number>; lowestTier: TierName }
+		{
+			tiers: Map<TierName, number>
+			addonTiers: { label: string; expected: number }[]
+			lowestTier: TierName | null
+		}
 	>()
 
 	for (const exp of expectations) {
 		let entry = map.get(exp.itemId)
 		if (!entry) {
-			entry = { tiers: new Map(), lowestTier: exp.tier }
+			entry = { tiers: new Map(), addonTiers: [], lowestTier: exp.tier }
 			map.set(exp.itemId, entry)
 		}
 
@@ -57,9 +67,23 @@ export function aggregateByItemId(
 		entry.tiers.set(exp.tier, current + exp.expectedPerChest)
 
 		// Track lowest tier (FR-003a)
-		if (TIER_ORDER[exp.tier] < TIER_ORDER[entry.lowestTier]) {
+		if (
+			entry.lowestTier === null ||
+			TIER_ORDER[exp.tier] < TIER_ORDER[entry.lowestTier]
+		) {
 			entry.lowestTier = exp.tier
 		}
+	}
+
+	// Merge addon expectations
+	for (const addon of addonExpectations) {
+		let entry = map.get(addon.itemId)
+		if (!entry) {
+			entry = { tiers: new Map(), addonTiers: [], lowestTier: null }
+			map.set(addon.itemId, entry)
+		}
+		const label = addon.group.charAt(0).toUpperCase() + addon.group.slice(1)
+		entry.addonTiers.push({ label, expected: addon.expectedPerChest })
 	}
 
 	// Convert to sorted array
@@ -77,7 +101,23 @@ export function aggregateByItemId(
 		for (const tier of TIER_NAMES) {
 			const value = entry.tiers.get(tier)
 			if (value !== undefined && value > 0) {
-				tiers.push({ tier, expectedPerX: value * perXChests })
+				const label = tier.charAt(0).toUpperCase() + tier.slice(1)
+				tiers.push({
+					tier,
+					rollTierLabel: label,
+					expectedPerX: value * perXChests,
+				})
+			}
+		}
+
+		// Addon sub-rows after regular tiers
+		for (const addonTier of entry.addonTiers) {
+			if (addonTier.expected > 0) {
+				tiers.push({
+					tier: null,
+					rollTierLabel: addonTier.label,
+					expectedPerX: addonTier.expected * perXChests,
+				})
 			}
 		}
 

--- a/src/pages/loot-tables/chests/computeAddonExpectations.ts
+++ b/src/pages/loot-tables/chests/computeAddonExpectations.ts
@@ -1,0 +1,64 @@
+import type {
+	TieredLootTableLevel,
+	TierName,
+} from "../../../models/tieredLootTable"
+import { TIER_NAMES } from "../../../models/tieredLootTable"
+import type { TieredLootTableAddon } from "../../../models/tieredLootTableAddon"
+import { computeEffectiveWeights, computePoolProbabilities } from "./rarity"
+
+/** Result of addon expected value calculation. */
+export interface AddonItemExpectation {
+	itemId: string
+	/** Addon group name (e.g., "unmodified") */
+	group: string
+	/** Expected amount per single chest (before multiplying by X) */
+	expectedPerChest: number
+}
+
+/**
+ * Compute expected values for addon items.
+ *
+ * For each addon item:
+ *   Σ(P(tier) × rollChance[tier]) × count
+ *
+ * - P(tier) comes from the parent chest's rarity-adjusted tier probabilities
+ * - rollChance[tier] is the addon's per-tier chance (e.g., 5% common, 100% omega)
+ * - Item Quantity has NO effect on addon items (they bypass the loot table)
+ *
+ * Only includes addons where level >= addon.levelRequirement.
+ */
+export function computeAddonExpectations(
+	addons: TieredLootTableAddon[],
+	segment: TieredLootTableLevel,
+	itemRarityPct: number,
+	level: number,
+): AddonItemExpectation[] {
+	const effectiveWeights = computeEffectiveWeights(segment, itemRarityPct)
+	const poolProbs = computePoolProbabilities(effectiveWeights)
+
+	const results: AddonItemExpectation[] = []
+
+	for (const addon of addons) {
+		if (level < addon.levelRequirement) continue
+
+		for (const item of addon.items) {
+			// Weighted average chance across tiers
+			let expectedChance = 0
+			for (const tier of TIER_NAMES) {
+				expectedChance += poolProbs[tier] * item.rollChanges[tier as TierName]
+			}
+
+			const expectedPerChest = expectedChance * item.count
+
+			results.push({
+				itemId: item.id,
+				group: addon.group,
+				expectedPerChest: Number.isFinite(expectedPerChest)
+					? expectedPerChest
+					: 0,
+			})
+		}
+	}
+
+	return results
+}

--- a/src/pages/loot-tables/chests/getItem.ts
+++ b/src/pages/loot-tables/chests/getItem.ts
@@ -101,6 +101,11 @@ const itemMap: Record<string, Item> = {
 		name: "Unidentified Magnet",
 		iconUrl: "/icons/the_vault_unidentified_magnet.gif",
 	},
+	"the_vault:vault_catalyst_fragment": {
+		id: "the_vault:vault_catalyst_fragment",
+		name: "Catalyst Fragment",
+		iconUrl: "/icons/the_vault_catalyst_fragment.png",
+	},
 	"sophisticatedbackpacks:backpack": {
 		id: "sophisticatedbackpacks:backpack",
 		name: "Pouch",

--- a/src/pages/loot-tables/chests/quantity.ts
+++ b/src/pages/loot-tables/chests/quantity.ts
@@ -1,27 +1,30 @@
 import type { Range } from "../../../models/tieredLootTable"
 
 /**
- * Apply Item Quantity scaling to roll and count ranges.
+ * Apply Item Quantity scaling to roll and count ranges for expected-value
+ * calculations. The game uses stochastic rounding (each whole unit is
+ * guaranteed and the fractional part is a probability of +1), so the
+ * expected value equals the continuous product — no flooring.
  *
  * For Item Quantity percentage q% (0–300%), multiplier m_q = 1 + q/100:
- * - minRoll = min(floor(minRoll * m_q), 54)
- * - maxRoll = min(floor(maxRoll * m_q), 54)
- * - minStack = floor(minStack * m_q)
- * - maxStack = floor(maxStack * m_q)
+ * - minRoll = min(minRoll * m_q, 54)
+ * - maxRoll = min(maxRoll * m_q, 54)
+ * - minStack = minStack * m_q
+ * - maxStack = maxStack * m_q
  */
 
 export function scaleRollRange(roll: Range, itemQuantityPct: number): Range {
 	const mq = 1 + itemQuantityPct * 0.01
 	return {
-		min: Math.min(Math.floor(roll.min * mq), 54),
-		max: Math.min(Math.floor(roll.max * mq), 54),
+		min: Math.min(roll.min * mq, 54),
+		max: Math.min(roll.max * mq, 54),
 	}
 }
 
 export function scaleCountRange(count: Range, itemQuantityPct: number): Range {
 	const mq = 1 + itemQuantityPct * 0.01
 	return {
-		min: Math.floor(count.min * mq),
-		max: Math.floor(count.max * mq),
+		min: count.min * mq,
+		max: count.max * mq,
 	}
 }

--- a/src/pages/loot-tables/chests/quantity.ts
+++ b/src/pages/loot-tables/chests/quantity.ts
@@ -11,7 +11,7 @@ import type { Range } from "../../../models/tieredLootTable"
  */
 
 export function scaleRollRange(roll: Range, itemQuantityPct: number): Range {
-	const mq = 1 + itemQuantityPct / 100
+	const mq = 1 + itemQuantityPct * 0.01
 	return {
 		min: Math.min(Math.floor(roll.min * mq), 54),
 		max: Math.min(Math.floor(roll.max * mq), 54),
@@ -19,7 +19,7 @@ export function scaleRollRange(roll: Range, itemQuantityPct: number): Range {
 }
 
 export function scaleCountRange(count: Range, itemQuantityPct: number): Range {
-	const mq = 1 + itemQuantityPct / 100
+	const mq = 1 + itemQuantityPct * 0.01
 	return {
 		min: Math.floor(count.min * mq),
 		max: Math.floor(count.max * mq),

--- a/src/pages/loot-tables/chests/rarity.ts
+++ b/src/pages/loot-tables/chests/rarity.ts
@@ -17,7 +17,7 @@ export function computeEffectiveWeights(
 	segment: TieredLootTableLevel,
 	itemRarityPct: number,
 ): Record<TierName, number> {
-	const mr = 1 + itemRarityPct / 100
+	const mr = 1 + itemRarityPct * 0.01
 
 	return {
 		common: segment.common.weight,

--- a/src/pages/loot-tables/chests/tierStyles.ts
+++ b/src/pages/loot-tables/chests/tierStyles.ts
@@ -17,6 +17,12 @@ export const TIER_COLOR_CLASSES: Record<TierName, string> = {
 	omega: "text-green-500/80",
 }
 
+/** Returns the color class for a tier, or a default for addon items (null tier). */
+export function getTierColorClass(tier: TierName | null): string {
+	if (tier === null) return "text-yellow-500/80"
+	return TIER_COLOR_CLASSES[tier]
+}
+
 /** Human-readable tier labels for display (FR-003a: not color alone). */
 export const TIER_LABELS: Record<TierName, string> = {
 	common: "Common",

--- a/src/pages/loot-tables/chests/tierStyles.ts
+++ b/src/pages/loot-tables/chests/tierStyles.ts
@@ -1,5 +1,5 @@
 import type { TierName } from "../../../models/tieredLootTable"
-import type { AddonGroups } from "../../../models/tieredLootTableAddon"
+import { AddonGroups } from "../../../models/tieredLootTableAddon"
 
 /**
  * Tier rarity visual treatment (FR-003a).

--- a/src/pages/loot-tables/chests/tierStyles.ts
+++ b/src/pages/loot-tables/chests/tierStyles.ts
@@ -1,4 +1,5 @@
 import type { TierName } from "../../../models/tieredLootTable"
+import { AddonGroups } from "../../../models/tieredLootTableAddon"
 
 /**
  * Tier rarity visual treatment (FR-003a).
@@ -29,4 +30,9 @@ export const TIER_LABELS: Record<TierName, string> = {
 	rare: "Rare",
 	epic: "Epic",
 	omega: "Omega",
+}
+
+/** Tooltip descriptions for addon group names. */
+export const addonGroupDescriptions: Record<AddonGroups, string> = {
+	[AddonGroups.unmodified]: "Drops in unmodified vaults",
 }

--- a/src/pages/loot-tables/chests/tierStyles.ts
+++ b/src/pages/loot-tables/chests/tierStyles.ts
@@ -1,5 +1,5 @@
 import type { TierName } from "../../../models/tieredLootTable"
-import { AddonGroups } from "../../../models/tieredLootTableAddon"
+import type { AddonGroups } from "../../../models/tieredLootTableAddon"
 
 /**
  * Tier rarity visual treatment (FR-003a).

--- a/src/pages/loot-tables/chests/tierStyles.ts
+++ b/src/pages/loot-tables/chests/tierStyles.ts
@@ -11,7 +11,7 @@ import { AddonGroups } from "../../../models/tieredLootTableAddon"
  * - Epic → Purple
  * - Omega → Green
  */
-export const TIER_COLOR_CLASSES: Record<TierName, string> = {
+export const tierColorClasses: Record<TierName, string> = {
 	common: "text-white/80",
 	rare: "text-blue-500/80",
 	epic: "text-purple-500/80",
@@ -21,11 +21,11 @@ export const TIER_COLOR_CLASSES: Record<TierName, string> = {
 /** Returns the color class for a tier, or a default for addon items (null tier). */
 export function getTierColorClass(tier: TierName | null): string {
 	if (tier === null) return "text-yellow-500/80"
-	return TIER_COLOR_CLASSES[tier]
+	return tierColorClasses[tier]
 }
 
 /** Human-readable tier labels for display (FR-003a: not color alone). */
-export const TIER_LABELS: Record<TierName, string> = {
+export const tierLabels: Record<TierName, string> = {
 	common: "Common",
 	rare: "Rare",
 	epic: "Epic",

--- a/src/pages/loot-tables/chests/useChestData.ts
+++ b/src/pages/loot-tables/chests/useChestData.ts
@@ -2,13 +2,15 @@ import { useEffect, useState } from "react"
 import type { JsonIndex, JsonIndexEntry } from "../../../models/jsonIndex"
 import type { TieredLootTable } from "../../../models/tieredLootTable"
 import { fetchJson } from "../shared/fetchJson"
+import { TieredLootTableAddon } from "@models/tieredLootTableAddon"
 
 const INDEX_URL = "/data/loot_tables/index.json"
 const BASE_URL = "/data/loot_tables/"
 
 export interface ChestLoadResult {
 	entry: JsonIndexEntry
-	data: TieredLootTable | null
+	chest: TieredLootTable | null
+	addons: TieredLootTableAddon[]
 	error: string | null
 }
 
@@ -46,6 +48,8 @@ export function useChestData(): UseChestDataReturn {
 				)
 				setIndexEntries(visible)
 
+				// TODO: Add addons
+
 				// Load individual chest files in parallel
 				const results = await Promise.all(
 					visible.map(async (entry): Promise<ChestLoadResult> => {
@@ -53,11 +57,11 @@ export function useChestData(): UseChestDataReturn {
 							const data = await fetchJson<TieredLootTable>(
 								`${BASE_URL}${entry.file}`,
 							)
-							return { entry, data, error: null }
+							return { entry, chest: data, error: null }
 						} catch (err) {
 							return {
 								entry,
-								data: null,
+								chest: null,
 								error:
 									err instanceof Error
 										? err.message

--- a/transformer/bin/generate-loot-tables.ts
+++ b/transformer/bin/generate-loot-tables.ts
@@ -1,11 +1,28 @@
+import * as fs from "node:fs"
+import path from "node:path"
+import type { JsonIndex } from "../../src/models/jsonIndex"
 import { generateChestLootTables } from "../loot_tables/chests"
+import { generateChestLootTableAddons } from "../loot_tables/chestsAddon"
 
 const SOURCE_DIR = "the_vault/gen/1.0/loot_tables"
 const OUTPUT_DIR = "public/data/loot_tables"
 
 async function main() {
-	console.log("Generating loot tables...")
-	await generateChestLootTables(SOURCE_DIR, OUTPUT_DIR)
+	console.log("Deleting existing loot tables...")
+	fs.rmSync(OUTPUT_DIR, { recursive: true, force: true })
+
+	const index: JsonIndex = []
+
+	console.log("Generating chest loot tables...")
+	await generateChestLootTables(SOURCE_DIR, OUTPUT_DIR, index)
+	console.log("Generating chest addon loot tables...")
+	generateChestLootTableAddons(SOURCE_DIR, index)
+
+	// Index
+	console.log("Writing index file")
+	const indexPath = path.join(OUTPUT_DIR, "index.json")
+	fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`)
+	console.log(`  Written: index.json (${index.length} entries)`)
 	console.log("Done.")
 }
 

--- a/transformer/bin/generate-loot-tables.ts
+++ b/transformer/bin/generate-loot-tables.ts
@@ -16,7 +16,7 @@ async function main() {
 	console.log("Generating chest loot tables...")
 	await generateChestLootTables(SOURCE_DIR, OUTPUT_DIR, index)
 	console.log("Generating chest addon loot tables...")
-	generateChestLootTableAddons(SOURCE_DIR, index)
+	generateChestLootTableAddons(OUTPUT_DIR, index)
 
 	// Index
 	console.log("Writing index file")

--- a/transformer/loot_tables/chests.ts
+++ b/transformer/loot_tables/chests.ts
@@ -44,6 +44,7 @@ const CHEST_CATEGORY_ORDER = [
 export async function generateChestLootTables(
 	sourceDir: string,
 	outputDir: string,
+	index: JsonIndex,
 ): Promise<void> {
 	// Ensure output directory exists
 	fs.mkdirSync(outputDir, { recursive: true })
@@ -121,11 +122,11 @@ export async function generateChestLootTables(
 	// Sort entries in display order
 	const sorted = sortByDisplayOrder(entries)
 
+	// Read index if it exists to preserve any existing values
+
 	// Write index
-	const index: JsonIndex = sorted.map((e) => e.entry)
-	const indexPath = path.join(outputDir, "index.json")
-	fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`)
-	console.log(`  Written: index.json (${index.length} entries)`)
+	const addToIndex: JsonIndex = sorted.map((e) => e.entry)
+	index.push(...addToIndex)
 }
 
 /**

--- a/transformer/loot_tables/chestsAddon.ts
+++ b/transformer/loot_tables/chestsAddon.ts
@@ -42,7 +42,7 @@ function catalystFragmentsForWoodenChests(outputDir: string, index: JsonIndex) {
 
 	index.push({
 		id: id as IndexId,
-		parentId: "chest_wooden" as IndexId,
+		parentId: "wooden_chest" as IndexId,
 		type: JsonIndexTypes.chestAddon,
 		file: `${id}.json`,
 	})

--- a/transformer/loot_tables/chestsAddon.ts
+++ b/transformer/loot_tables/chestsAddon.ts
@@ -5,7 +5,10 @@ import {
 	type JsonIndex,
 	JsonIndexTypes,
 } from "../../src/models/jsonIndex"
-import type { TieredLootTableAddon } from "../../src/models/tieredLootTableAddon"
+import {
+	AddonGroups,
+	type TieredLootTableAddon,
+} from "../../src/models/tieredLootTableAddon"
 
 export function generateChestLootTableAddons(
 	outputDir: string,
@@ -17,6 +20,7 @@ export function generateChestLootTableAddons(
 function catalystFragmentsForWoodenChests(outputDir: string, index: JsonIndex) {
 	const addon: TieredLootTableAddon = {
 		id: "chest_wooden_catalyst" as IndexId,
+		group: AddonGroups.unmodified,
 		levelRequirement: 20,
 		items: [
 			{

--- a/transformer/loot_tables/chestsAddon.ts
+++ b/transformer/loot_tables/chestsAddon.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs"
+import type { ItemId } from "../../src/models/item"
+import {
+	type IndexId,
+	type JsonIndex,
+	JsonIndexTypes,
+} from "../../src/models/jsonIndex"
+import type { TieredLootTableAddon } from "../../src/models/tieredLootTableAddon"
+
+export function generateChestLootTableAddons(
+	outputDir: string,
+	index: JsonIndex,
+) {
+	catalystFragmentsForWoodenChests(outputDir, index)
+}
+
+function catalystFragmentsForWoodenChests(outputDir: string, index: JsonIndex) {
+	const addon: TieredLootTableAddon = {
+		id: "chest_wooden_catalyst" as IndexId,
+		levelRequirement: 20,
+		items: [
+			{
+				id: "the_vault:vault_catalyst_fragment" as ItemId,
+				count: 1,
+				rollChanges: {
+					common: 0.05,
+					rare: 0.2,
+					epic: 0.5,
+					omega: 1,
+				},
+			},
+		],
+	}
+	const id = "chest_wooden_catalyst"
+	const addonFilePath = `${outputDir}/${id}.json`
+	fs.writeFileSync(addonFilePath, `${JSON.stringify(addon, null, 2)}\n`)
+	console.log(`  Written: ${id}.json`)
+
+	index.push({
+		id: id as IndexId,
+		parentId: "chest_wooden" as IndexId,
+		type: JsonIndexTypes.chestAddon,
+		file: `${id}.json`,
+	})
+}


### PR DESCRIPTION
## Description

Adds Catalyst Fragments to Wooden Chests and fixes ItemQuantity calculation.


Closes #32

## Checklist

- [x] I have reviewed my own code
- [x] Tested locally with `yarn dev`
